### PR TITLE
refactor: some details

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -33,7 +33,7 @@ func (err *ErrInfo) Error() string {
 	return string(res)
 }
 
-// 1000-2000 filebeat 相关错误码
+// 1000-1999 filebeat 相关错误码
 func FileBeatConfError(format string, a ...interface{}) *ErrInfo {
 	return newErrInfo(1000, "filebeat-conf-error", fmt.Sprintf(format, a...))
 }
@@ -51,6 +51,11 @@ func DbClusterNotFoundById(id int32) *ErrInfo {
 	return DbClusterNotFound(msg)
 }
 func DbClusterNotFoundByName(name string) *ErrInfo {
-	msg := fmt.Sprintf("dbcluster with name=%d not found", name)
+	msg := fmt.Sprintf("dbcluster with name=%s not found", name)
 	return DbClusterNotFound(msg)
+}
+
+// 3000-3999 配置相关错误
+func AgentConfigError(format string, a ...interface{}) *ErrInfo {
+	return newErrInfo(3000, "agent-conf-error", fmt.Sprintf(format, a...))
 }

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -35,7 +35,7 @@ func (err *ErrInfo) Error() string {
 
 // 1000-1999 filebeat 相关错误码
 func FileBeatConfError(format string, a ...interface{}) *ErrInfo {
-	return newErrInfo(1000, "filebeat-conf-error", fmt.Sprintf(format, a...))
+	return newErrInfo(1000, "FilebeatConfError", fmt.Sprintf(format, a...))
 }
 
 // 2000 - 2999 dbcluster 相关
@@ -57,5 +57,5 @@ func DbClusterNotFoundByName(name string) *ErrInfo {
 
 // 3000-3999 配置相关错误
 func AgentConfigError(format string, a ...interface{}) *ErrInfo {
-	return newErrInfo(3000, "agent-conf-error", fmt.Sprintf(format, a...))
+	return newErrInfo(3000, "AgentConfError", fmt.Sprintf(format, a...))
 }

--- a/filebeat/alive_listener.go
+++ b/filebeat/alive_listener.go
@@ -14,40 +14,44 @@ type (
 		Listen(ctx context.Context)
 	}
 
+	AliveSuccCallback  func(ctx context.Context, resp string)
 	AliveErrorCallback func(ctx context.Context, err error)
+
+	AliveListenerCallback struct {
+		ErrorCallback AliveErrorCallback
+		SuccCallback  AliveSuccCallback
+	}
 )
 
-func NewAliveListener(host string, client utils.HttpClient, interval, delay time.Duration, callback AliveErrorCallback) AliveListener {
+func NewAliveListener(host string, client utils.HttpClient, interval time.Duration, callbacks *AliveListenerCallback) AliveListener {
 	return &filebeatAliveListener{
-		host:          host,
-		client:        client,
-		interval:      interval,
-		delay:         delay,
-		errorCallback: callback,
+		host:      host,
+		client:    client,
+		interval:  interval,
+		callbacks: callbacks,
 	}
 }
 
 // alive check details: https://www.elastic.co/guide/en/beats/filebeat/current/http-endpoint.html
 // `http.enabled == true` is guaranteed in conf validater.
 type filebeatAliveListener struct {
-	host          string
-	client        utils.HttpClient
-	interval      time.Duration
-	delay         time.Duration // some time for filebeat startup
-	errorCallback AliveErrorCallback
+	host      string
+	client    utils.HttpClient
+	interval  time.Duration
+	callbacks *AliveListenerCallback
 }
 
 func (f *filebeatAliveListener) Listen(ctx context.Context) {
 	url := fmt.Sprintf("http://%s/?pretty", f.host)
 
 	go func() {
-		time.Sleep(f.delay)
-
 		for {
 			resp, err := f.client.Send(ctx, url, "GET", "")
-			logger.Infof("alive check resp: %v, err:%v", resp, err)
+			logger.Infof("alive check resp: %s, err:%v", string(resp), err)
 			if err != nil {
-				f.errorCallback(ctx, err)
+				f.callbacks.ErrorCallback(ctx, err)
+			} else {
+				f.callbacks.SuccCallback(ctx, string(resp))
 			}
 
 			time.Sleep(f.interval)

--- a/filebeat/alive_listener_test.go
+++ b/filebeat/alive_listener_test.go
@@ -29,7 +29,7 @@ func TestFilebeatAliveListener_Listen(t *testing.T) {
 	callback := func(ctx context.Context, err error) {
 		errMsgs <- err.Error()
 	}
-	listener := NewAliveListener("", httpClient, 0, 0, callback)
+	listener := NewAliveListener("", httpClient, 0, &AliveListenerCallback{ErrorCallback: callback})
 	listener.Listen(context.Background())
 
 	assert.Equal(t, <-errMsgs, "111")

--- a/filebeat/conf_generator_test.go
+++ b/filebeat/conf_generator_test.go
@@ -16,7 +16,7 @@ output.dbrainhub:
   timeout: 2`
 	conf, err := model.NewFileBeatConfFactory().NewFilebeatConf(confContent)
 	assert.Nil(t, err)
-	assert.Error(t, NewConfGenerator("", nil).CanGenerateFilebeatConf(conf))
+	assert.Error(t, NewFilebeatConfGenerator(nil).CanGenerate(conf))
 }
 
 func TestConfGenImpl_CanGenerateFilebeatConf_True(t *testing.T) {
@@ -28,7 +28,7 @@ output.dbrainhub:
   timeout: 2`
 	conf, err := model.NewFileBeatConfFactory().NewFilebeatConf(confContent)
 	assert.Nil(t, err)
-	assert.Nil(t, NewConfGenerator("", nil).CanGenerateFilebeatConf(conf))
+	assert.Nil(t, NewFilebeatConfGenerator(nil).CanGenerate(conf))
 }
 
 func TestConfGenImpl_CanGenerateModuleConf_Error(t *testing.T) {
@@ -39,7 +39,7 @@ func TestConfGenImpl_CanGenerateModuleConf_Error(t *testing.T) {
     var.paths: ["/path/to/log/mysql/mysql-slow.log*"]`
 	conf, err := model.NewFileBeatConfFactory().NewModuleConf(confContent, model.InputModuleType)
 	assert.Nil(t, err)
-	assert.Error(t, NewConfGenerator("", nil).CanGenerateModuleConf(conf))
+	assert.Error(t, NewModuleConfGenerator("").CanGenerate(conf))
 }
 
 func TestConfGenImpl_CanGenerateModuleConf_True(t *testing.T) {
@@ -50,7 +50,7 @@ func TestConfGenImpl_CanGenerateModuleConf_True(t *testing.T) {
     var.paths: ["$input_path"]`
 	conf, err := model.NewFileBeatConfFactory().NewModuleConf(confContent, model.InputModuleType)
 	assert.Nil(t, err)
-	assert.Nil(t, NewConfGenerator("", nil).CanGenerateModuleConf(conf))
+	assert.Nil(t, NewModuleConfGenerator("").CanGenerate(conf))
 }
 
 func TestConfGenImpl_GenerateModuleConf(t *testing.T) {
@@ -60,8 +60,8 @@ func TestConfGenImpl_GenerateModuleConf(t *testing.T) {
     enabled: true
     var.paths: ["$input_path"]`
 
-	gen := NewConfGenerator("123", nil)
-	assert.Equal(t, gen.GenerateModuleConf(confContent), `
+	gen := NewModuleConfGenerator("123")
+	assert.Equal(t, gen.Generate(confContent), `
 - module: mysql
   slowlog:
     enabled: true
@@ -75,8 +75,8 @@ output.dbrainhub:
   batch_size: 20480
   retry_limit: 5
   timeout: 2`
-	gen := NewConfGenerator("", []string{"123", "456"})
-	assert.Equal(t, gen.GenerateFilebeatConf(confContent), `
+	gen := NewFilebeatConfGenerator([]string{"123", "456"})
+	assert.Equal(t, gen.Generate(confContent), `
 output.dbrainhub:
   hosts: ["127.0.0.1:10010","123","456"]
   batch_size: 20480

--- a/filebeat/conf_validater.go
+++ b/filebeat/conf_validater.go
@@ -27,7 +27,7 @@ func (c *confValidator) ValidateFilebeatConf(template string) error {
 	}
 
 	// can configure output?
-	if err := NewConfGenerator("", nil).CanGenerateFilebeatConf(conf); err != nil {
+	if err := NewFilebeatConfGenerator(nil).CanGenerate(conf); err != nil {
 		return err
 	}
 
@@ -49,7 +49,7 @@ func (c *confValidator) ValidateModuleConf(template string) error {
 	}
 
 	// can configure input?
-	if err := NewConfGenerator("", nil).CanGenerateModuleConf(conf); err != nil {
+	if err := NewModuleConfGenerator("").CanGenerate(conf); err != nil {
 		return err
 	}
 	return nil

--- a/filebeat/slowlog_listener.go
+++ b/filebeat/slowlog_listener.go
@@ -21,7 +21,7 @@ type (
 	}
 )
 
-func NewSlowLogPathListener(slowLogQuerier model.SlowLogInfoQuerier, interval time.Duration, callbacks SlowLogPathCallback) SlowLogPathListener {
+func NewSlowLogPathListener(slowLogQuerier model.SlowLogInfoQuerier, interval time.Duration, callbacks *SlowLogPathCallback) SlowLogPathListener {
 	return &slowLogPathListener{
 		slowLogQuerier: slowLogQuerier,
 		interval:       interval,
@@ -32,7 +32,7 @@ func NewSlowLogPathListener(slowLogQuerier model.SlowLogInfoQuerier, interval ti
 type slowLogPathListener struct {
 	slowLogQuerier model.SlowLogInfoQuerier
 	interval       time.Duration
-	callbacks      SlowLogPathCallback
+	callbacks      *SlowLogPathCallback
 }
 
 func (s *slowLogPathListener) Listen(ctx context.Context) {

--- a/filebeat/slowlog_listener_test.go
+++ b/filebeat/slowlog_listener_test.go
@@ -14,7 +14,7 @@ func TestSlowLogPathListener_Listen(t *testing.T) {
 
 	// use chan for testing logic in another gorounte
 	msgChan := make(chan string)
-	callbacks := SlowLogPathCallback{
+	callbacks := &SlowLogPathCallback{
 		ChangedCallback: func(ctx context.Context, oldPath, newPath string) {
 			msgChan <- newPath
 		},
@@ -36,7 +36,7 @@ func TestSlowLogPathListener_ListenError(t *testing.T) {
 	var slowPathArr = []string{"111", "222", "222", "333", "333"}
 
 	msgChan := make(chan string)
-	callbacks := SlowLogPathCallback{
+	callbacks := &SlowLogPathCallback{
 		ChangedCallback: nil,
 		ErrorCallback: func(ctx context.Context, err error) {
 			msgChan <- err.Error()

--- a/model/filebeatconf_factory.go
+++ b/model/filebeatconf_factory.go
@@ -50,7 +50,7 @@ func (f *filebeatConfFactory) parse(confContent string, conf interface{}) error 
 	err = cfg.Unpack(conf)
 	if err != nil {
 		logger.Infof("config unpack err: %v", err)
-		return errors.FileBeatConfError("cfg unpack error:%v", err)
+		return errors.FileBeatConfError("cfg unpack error")
 	}
 
 	return nil

--- a/model/slowlog_querier_test.go
+++ b/model/slowlog_querier_test.go
@@ -11,11 +11,11 @@ import (
 )
 
 const (
-	User          = "root"
-	Passwd        = "123"
-	Addr          = "127.0.0.1:3306"
-	IsOpenSlowLog = false
-	SlowLogPath   = "/usr/local/var/mysql/lypdeMacBook-Pro-slow.log"
+	user          = "root"
+	passwd        = "123"
+	addr          = "127.0.0.1:3306"
+	isOpenSlowLog = false
+	slowLogPath   = "/usr/local/var/mysql/lypdeMacBook-Pro-slow.log"
 	testSwitch    = false
 )
 
@@ -31,13 +31,13 @@ func TestQuerySlowLog(t *testing.T) {
 	slowLogInfo, err := NewSlowLogInfoQuerier(db).Query(context.Background())
 
 	assert.Nil(t, err)
-	assert.Equal(t, slowLogInfo.IsOpen, IsOpenSlowLog)
-	assert.Equal(t, slowLogInfo.Path, SlowLogPath)
+	assert.Equal(t, slowLogInfo.IsOpen, isOpenSlowLog)
+	assert.Equal(t, slowLogInfo.Path, slowLogPath)
 }
 
 func newDB(t *testing.T) (*sql.DB, error) {
 	db, err := sql.Open("mysql",
-		fmt.Sprintf("%s:%s@tcp(%s)/", User, Passwd, Addr))
+		fmt.Sprintf("%s:%s@tcp(%s)/", user, passwd, addr))
 	assert.Nil(t, err)
 	return db, err
 }

--- a/utils/file.go
+++ b/utils/file.go
@@ -1,0 +1,22 @@
+package utils
+
+import (
+	"io/ioutil"
+	"os"
+)
+
+func ReadFile(filePath string) (string, error) {
+	bytes, err := ioutil.ReadFile(filePath)
+	return string(bytes), err
+}
+
+func OverwriteToFile(filePath string, content string) error {
+	f, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE, 0666)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	_, err = f.Write([]byte(content))
+	return err
+}

--- a/utils/http_client.go
+++ b/utils/http_client.go
@@ -76,7 +76,7 @@ func (h *httpClient) Send(ctx context.Context, url, method, body string) ([]byte
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("http resp code: %d", resp.StatusCode)
+		return nil, fmt.Errorf("http resp code: %d, resp: %s", resp.StatusCode, string(respBytes))
 	}
 	return respBytes, nil
 }

--- a/utils/http_client.go
+++ b/utils/http_client.go
@@ -70,13 +70,13 @@ func (h *httpClient) Send(ctx context.Context, url, method, body string) ([]byte
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("http resp code: %d", resp.StatusCode)
-	}
-
 	respBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("read resp body error, err:%v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("http resp code: %d", resp.StatusCode)
 	}
 	return respBytes, nil
 }

--- a/utils/http_client.go
+++ b/utils/http_client.go
@@ -2,8 +2,81 @@ package utils
 
 import (
 	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"time"
 )
 
 type HttpClient interface {
 	Send(ctx context.Context, url, method, body string) ([]byte, error)
+}
+
+func NewHttpClient(timeout time.Duration, retry int, retryInterval time.Duration) HttpClient {
+	return &httpClientWithRetry{
+		limit:    retry,
+		interval: retryInterval,
+		client: &httpClientWithTimeout{
+			timeout: timeout,
+			client:  &httpClient{},
+		},
+	}
+}
+
+type httpClientWithTimeout struct {
+	timeout time.Duration
+	client  HttpClient
+}
+
+func (h *httpClientWithTimeout) Send(ctx context.Context, url, method, body string) ([]byte, error) {
+	ctxWithTiemout, cancel := context.WithTimeout(ctx, h.timeout)
+	defer cancel()
+
+	return h.client.Send(ctxWithTiemout, url, method, body)
+}
+
+type httpClientWithRetry struct {
+	limit    int
+	interval time.Duration
+	client   HttpClient
+}
+
+func (h *httpClientWithRetry) Send(ctx context.Context, url, method, body string) (resp []byte, err error) {
+	for i := 0; i <= h.limit; i++ {
+		resp, err = h.client.Send(ctx, url, method, body)
+		if err == nil {
+			return
+		}
+		time.Sleep(h.interval)
+	}
+	return
+}
+
+type httpClient struct {
+	client http.Client
+}
+
+func (h *httpClient) Send(ctx context.Context, url, method, body string) ([]byte, error) {
+	request, err := http.NewRequest(method, url, strings.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("new request error, err:%v", err)
+	}
+
+	request = request.WithContext(ctx)
+	resp, err := h.client.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("client do error, err:%v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("http resp code: %d", resp.StatusCode)
+	}
+
+	respBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read resp body error, err:%v", err)
+	}
+	return respBytes, nil
 }


### PR DESCRIPTION
details:
1. ConfGenerator interface 拆分到两个接口，因为两个接口的功能是互不相关的。
2. 去掉了filebeat alive listener 的 delay 参数，filebeat是否启动成功无法依赖这个参数，后续会结合callback + channel实现对filebeat启动成功的检测；
3. 引入 filebeat alive listener succ callback，方便后续实现filebeat启动成功的检测；
4. filebeat startup行为中，增加了一个返回值，两个io.Reader返回值分别代表stdout和stderr